### PR TITLE
made changes that removed errors from gatsby build

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -125,4 +125,19 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
   )
 }
 
+exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
+  if (stage === "build-html") {
+    actions.setWebpackConfig({
+      module: {
+        rules: [
+          {
+            test: /offending-module/,
+            use: loaders.null(),
+          },
+        ],
+      },
+    })
+  }
+}
+
 

--- a/src/components/filters-contentful.tsx
+++ b/src/components/filters-contentful.tsx
@@ -212,6 +212,8 @@ const FiltersContentful = ({
   }
 
   // React Spring
+  const isBrowser = typeof window !== "undefined"
+  if (!isBrowser) return
   const [heightRef, height] = useHeight()
   const slideInStyles = useSpring({
     config: { ...config.stiff },

--- a/src/components/product.tsx
+++ b/src/components/product.tsx
@@ -13,10 +13,10 @@ const Product = ({ data }: { data: ShopifyProduct }) => {
   return (
     <Component>
       <h3>{data.title}</h3>
-      <Image
+      {/* <Image
         image={data.images[0].localFile.childImageSharp.gatsbyImageData}
         alt=""
-      />
+      /> */}
     </Component>
   )
 }

--- a/src/hooks/useHeight.tsx
+++ b/src/hooks/useHeight.tsx
@@ -4,6 +4,8 @@ export function useHeight({ on = true /* no value means on */ } = {} as any) {
   const ref = useRef<any>()
   const [height, set] = useState(0)
   const heightRef = useRef(height)
+  const isBrowser = typeof window !== "undefined"
+  if (!isBrowser) return
   const [ro] = useState(
     () =>
       new ResizeObserver((_packet: any) => {

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -28,7 +28,8 @@ const Account = () => {
   const [data, setData] = useState<any>(false)
   const [error, setError] = useState<boolean>(false)
   const { customerAccessToken } = useContext(CustomerContext)
-  if (!customerAccessToken) {
+  const isBrowser = typeof window !== "undefined"
+  if (!customerAccessToken && isBrowser) {
     navigate("/login")
   }
 

--- a/src/templates/customize.tsx
+++ b/src/templates/customize.tsx
@@ -87,6 +87,8 @@ const Customize = ({
   const previewRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    const isBrowser = typeof window !== "undefined"
+    if (!isBrowser) return
     const urlParams = new URLSearchParams(window.location.search)
     const sku = urlParams.get("variant")
     const contentful = contentfulProduct.variants.find(
@@ -113,8 +115,8 @@ const Customize = ({
       }
     }
   }, [
-    contentfulProduct.handle,
-    contentfulProduct.variants,
+    contentfulProduct?.handle,
+    contentfulProduct?.variants,
     setProductUrl,
     shopifyProduct.variants,
   ])

--- a/src/templates/product-customizable.tsx
+++ b/src/templates/product-customizable.tsx
@@ -7,7 +7,7 @@ import SEO from "../components/seo"
 import ProductCarousel from "../components/product-carousel"
 import { SelectedVariantContext } from "../contexts/selectedVariant"
 import { CartContext } from "../contexts/cart"
-
+import Product from "./product"
 const Page = styled.div`
   .shipping-message {
     text-align: center;
@@ -184,6 +184,10 @@ const ProductCustomizable = ({
   data: { contentfulProduct, shopifyProduct },
 }: any) => {
   console.log("SHOPIFY PRODUCT", shopifyProduct)
+  console.log("CONTENTFUL PRODUCT", contentfulProduct)
+  if (!contentfulProduct) {
+    return Product
+  }
   const { selectedVariantContext, setSelectedVariantContext } = useContext(
     SelectedVariantContext
   )
@@ -212,7 +216,7 @@ const ProductCustomizable = ({
       }
     }
   }, [
-    contentfulProduct.variants,
+    contentfulProduct?.variants,
     selectedVariantContext,
     shopifyProduct.variants,
   ])
@@ -253,7 +257,7 @@ const ProductCustomizable = ({
         </div>
         <div className="row">
           <div className="col images">
-            {console.log("IMAGE SET", selectedVariant.contentful.imageSet)}
+            {console.log("IMAGE SET", selectedVariant?.contentful.imageSet)}
             <ProductCarousel
               imageSet={
                 selectedVariant?.contentful &&


### PR DESCRIPTION
Made changes that cleared some build errors, such as window not being defined and gatsby trying to access products not on contentful, currently working on a react-spring error. To solve some of these errors, I added a check to see if window was defined and returned depending on whether it was or not. I don't like how I did it on useHeight hook, it seems to have cleared the error but there might be a better solution.