### PR TITLE
Shopify redirect

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -148,7 +148,7 @@ const Header = ({
   setIsDrawerOpen,
   isIndex,
 }: HeaderProps) => {
-  const { customerAccessToken, logout } = useContext(CustomerContext)
+  const { customerAccessToken } = useContext(CustomerContext)
   const [currentPath, setCurrentPath] = useState("/")
   const [visibleAccountSubNav, setVisibileAccountSubNav] =
     useState<boolean>(false)
@@ -225,9 +225,12 @@ const Header = ({
               <FaSearch />
             </Link>
             {!customerAccessToken ? (
-              <Link to="/login" className="login-text">
+              <a
+                href="https://www.tresnoir.com/account/login"
+                className="login-text"
+              >
                 LOG IN
-              </Link>
+              </a>
             ) : (
               <span className="accounts">
                 <a
@@ -240,13 +243,15 @@ const Header = ({
                 {visibleAccountSubNav && (
                   <ul ref={ref} className="accounts-sub-nav sub-nav">
                     <li>
-                      <Link to="/account">YOUR ACCOUNT</Link>
+                      <a href="https://www.tresnoir.com/account">
+                        YOUR ACCOUNT
+                      </a>
                     </li>
-                    <li>
+                    {/* <li>
                       <a href="#" onClick={logout}>
                         LOG OUT
                       </a>
-                    </li>
+                    </li> */}
                   </ul>
                 )}
               </span>

--- a/src/contexts/customer.tsx
+++ b/src/contexts/customer.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, ReactChild, useState, useMemo } from "react"
 import Cookies from "js-cookie"
 
-const customerAccessTokenCookie = "tn_g_auth"
-const customerEmailCookie = "tn_g_customer"
+const customerAccessTokenCookie = "_tn_cat"
+const customerEmailCookie = "_tn_customer_email"
 
 interface DefaultContext {
   customerAccessToken: null | string


### PR DESCRIPTION
# Changes
- Removing header link to login, redirecting to Shopify instead
- Shopify should create a usable cookie and redirect back