### PR TITLE
Updated contentful glasses collections

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = {
         // Include GTM in development.
         //
         // Defaults to false meaning GTM will only be loaded in production.
-        includeInDevelopment: false,
+        includeInDevelopment: true,
 
         // datalayer to be set before GTM is loaded
         // should be an object or a function that is executed in the browser

--- a/src/components/product-contentful.tsx
+++ b/src/components/product-contentful.tsx
@@ -45,11 +45,21 @@ const Component = styled.article`
 interface Props {
   data: ContentfulProduct
   color: null | string
+  collectionHandle: string
 }
 
-const ProductContentful = ({ data, color }: Props) => {
+const ProductContentful = ({ data, color, collectionHandle }: Props) => {
   const { setSelectedVariantContext } = useContext(SelectedVariantContext)
-  const defaultImage = data.variants[0].featuredImage.data
+
+  const isSunglasses = collectionHandle.includes("sunglasses")
+
+  const defaultImage = isSunglasses
+    ? data.variants[0].featuredImage.data
+    : data.variants[0].featuredImageClear?.data
+    ? data.variants[0].featuredImageClear.data
+    : data.variants[0].featuredImage.data
+
+  // const defaultImage = data.variants[0].featuredImage.data
   const [variantImage, setVariantImage] =
     useState<IGatsbyImageData>(defaultImage)
 
@@ -62,16 +72,26 @@ const ProductContentful = ({ data, color }: Props) => {
     variant: ContentfulProductVariant
   ) => {
     // e.currentTarget && (e.currentTarget as HTMLElement).blur()
-    setVariantImage(variant.featuredImage.data)
+    const defaultImage = isSunglasses
+      ? variant.featuredImage.data
+      : variant.featuredImageClear?.data
+      ? variant.featuredImageClear.data
+      : variant.featuredImage.data
+    setVariantImage(defaultImage)
+    // setVariantImage(variant.featuredImage.data)
     setSelectedVariant({
       contentful: variant,
     })
     setSelectedVariantContext(variant.sku)
   }
 
+  const productLink = isSunglasses
+    ? `/products/${data.handle}?lens_type=sunglasses`
+    : `/products/${data.handle}?lens_type=glasses`
+
   return (
     <Component>
-      <Link to={`/products/${data.handle}`}>
+      <Link to={productLink}>
         <Img image={variantImage} alt={data.title} />
       </Link>
       <h3>{data.title}</h3>

--- a/src/templates/collection-contentful.tsx
+++ b/src/templates/collection-contentful.tsx
@@ -69,6 +69,7 @@ const CollectionContentful = ({
                 key={product.handle}
                 data={product}
                 color={filters.colorName}
+                collectionHandle={collection.handle}
               />
             ))
           ) : (
@@ -104,6 +105,9 @@ export const query = graphql`
           id
           sku
           featuredImage {
+            data: gatsbyImageData(width: 600)
+          }
+          featuredImageClear {
             data: gatsbyImageData(width: 600)
           }
           colorName

--- a/src/types/contentful.d.ts
+++ b/src/types/contentful.d.ts
@@ -6,6 +6,9 @@ export interface ContentfulProductVariant {
   featuredImage: {
     data: IGatsbyImageData
   }
+  featuredImageClear: {
+    data: IGatsbyImageData
+  }
   colorName: string
   colorImage: {
     data: IGatsbyImageData
@@ -25,6 +28,9 @@ export interface ContentfulCollection {
   handle: string
   name: string
   featuredImage: {
+    data: IGatsbyImageData
+  }
+  featuredImageClear: {
     data: IGatsbyImageData
   }
   products: ContentfulProduct[]


### PR DESCRIPTION
# Changes
- Updated content product variant content model
  - featuredImageClear
  - imageSetClear
- Updated Contentful Page & Collection Queries to source new fields
- Updated Contentful Page & Collection Templates to use `Sunglasses` as fallback when `Clear Glasses` images are not available. 
- Added `lens_type` url param on contentful collection