### PR TITLE
Fix to reset selected variant context on new collection view

### DIFF
--- a/src/templates/collection-contentful.tsx
+++ b/src/templates/collection-contentful.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from "react"
+import React, { useContext, useState, useEffect } from "react"
 import { graphql } from "gatsby"
 import styled from "styled-components"
 import { GatsbyImage } from "gatsby-plugin-image"
+import { SelectedVariantContext } from "../contexts/selectedVariant"
 import Product from "../components/product-contentful"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
@@ -73,6 +74,13 @@ const CollectionContentful = ({
   const [products, setProducts] = useState<ContentfulProduct[]>(
     collection.products
   )
+
+  const { setSelectedVariantContext } = useContext(SelectedVariantContext)
+
+  useEffect(() => {
+    // reset selected variant context
+    setSelectedVariantContext("")
+  }, [])
 
   return (
     <Layout>


### PR DESCRIPTION
# Changes
- Added reset of selected variant context when a new collection was viewed. For example if user selected the eyeglass amber waycooler and viewed it, then user viewed the sunglass collection and viewed the waycooler, which would now show the first variant as default. When the user clicks into the product the selected variant context would overwrite the default variant and the amber variant would display instead of the black.