### PR TITLE
Removed fit type from templates in place of frame width

### DIFF
--- a/src/components/product-contentful.tsx
+++ b/src/components/product-contentful.tsx
@@ -129,7 +129,9 @@ const ProductContentful = ({ data, color, collectionHandle }: Props) => {
     setProductLink(productLink => `${productLink}&variant=${variant.sku}`)
   }
 
-  const hasNewStyles = data.collection.some(col => col.handle === "new")
+  let hasNewStyles: boolean = false
+  if (data.collection.length > 0)
+    hasNewStyles = data.collection.some(col => col.handle === "new")
 
   return (
     <Component>

--- a/src/templates/customize.tsx
+++ b/src/templates/customize.tsx
@@ -212,7 +212,6 @@ export const query = graphql`
   query CustomizeQuery($handle: String) {
     contentfulProduct(handle: { eq: $handle }) {
       handle
-      fitType
       fitDimensions
       variants {
         colorName

--- a/src/templates/learn-more/index.tsx
+++ b/src/templates/learn-more/index.tsx
@@ -382,7 +382,10 @@ const LearnMore = ({ data: { contentfulProduct } }: any) => {
         <section className="fit-info">
           <div className="wrapper">
             <p className="h2">
-              {contentfulProduct.title} frames are a {contentfulProduct.fitType}{" "}
+              {contentfulProduct.title} frames are a{" "}
+              {contentfulProduct.frameWidth.length > 1
+                ? `${contentfulProduct.frameWidth[0]} to ${contentfulProduct.frameWidth[1]}`
+                : contentfulProduct.frameWidth[0]}{" "}
               fit.
             </p>
             <p className="h3">{contentfulProduct.fitDimensions}</p>
@@ -505,7 +508,7 @@ export const query = graphql`
         data: gatsbyImageData
       }
       fitDimensions
-      fitType
+      frameWidth
       handle
       lensesInfoImage {
         data: gatsbyImageData

--- a/src/templates/product-customizable.tsx
+++ b/src/templates/product-customizable.tsx
@@ -51,6 +51,7 @@ const Page = styled.div`
   }
   .heading {
     align-self: flex-start;
+    width: 100%;
   }
   h1 {
     font-weight: normal;
@@ -62,6 +63,7 @@ const Page = styled.div`
     color: var(--color-grey-dark);
     font-size: 1.5rem;
     text-transform: capitalize;
+    width: 100%;
     span {
       float: right;
     }
@@ -429,10 +431,11 @@ const ProductCustomizable = ({
               <p className="fit">
                 Size: {contentfulProduct && contentfulProduct.fitDimensions}{" "}
                 <span>
-                  {contentfulProduct &&
-                  contentfulProduct.fitType === "medium (average)"
-                    ? "medium"
-                    : contentfulProduct && contentfulProduct.fitType}{" "}
+                  {contentfulProduct && contentfulProduct.frameWidth.length > 1
+                    ? `${contentfulProduct.frameWidth[0]} to ${
+                        contentfulProduct.frameWidth[1]
+                      }${" "}`
+                    : `${contentfulProduct.frameWidth[0]}${" "}`}
                   fit
                 </span>
               </p>
@@ -442,7 +445,7 @@ const ProductCustomizable = ({
                 Color:{" "}
                 <span>
                   {lensType === LensType.GLASSES
-                    ? selectedVariant.shopify.title.replace("- Smoke Lens", "")
+                    ? selectedVariant.shopify.title.split(" - ")[0]
                     : selectedVariant.shopify.title}
                 </span>
               </p>
@@ -546,7 +549,7 @@ export const query = graphql`
   query ProductQuery($handle: String) {
     contentfulProduct(handle: { eq: $handle }) {
       handle
-      fitType
+      frameWidth
       fitDimensions
       variants {
         colorName

--- a/src/types/contentful.d.ts
+++ b/src/types/contentful.d.ts
@@ -21,7 +21,6 @@ export interface ContentfulProduct {
   handle: string
   id: string
   title: string
-  fitType: string
   frameWidth: string[]
   collection: {
     name: string

--- a/src/types/customize.d.ts
+++ b/src/types/customize.d.ts
@@ -2,7 +2,6 @@ import { IGatsbyImageData } from "gatsby-plugin-image"
 
 export interface ContentfulProduct {
   handle: string
-  fitType: string
   fitDimensions: string
   variants: ContentfulProductVariant[]
 }


### PR DESCRIPTION
# Changes
- Fit Type will be deprecated in favor of Frame Width, which allows multiple values, ex: `small`, `medium`
- Templates were updated to use the Frame Width property on the product instead of Fit Type