### PR TITLE
About section images were not 50 / 50, this will fix this

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -108,6 +108,9 @@ const Page = styled.div`
       @media only screen and (max-width: 480px) {
         display: block;
       }
+      .about-image {
+        flex: 1;
+      }
       .gatsby-image-wrapper {
         margin: 200px 20px 100px 20px;
         padding: 20px;


### PR DESCRIPTION
For w/e reason the about section (2 images) on the index page were not displaying properly after the last commit / merge, which had nothing to do with that component. added styling to fix this issue.