### PR TITLE
made Add rx context clear on change to Single vision

### DIFF
--- a/src/components/customization/form.tsx
+++ b/src/components/customization/form.tsx
@@ -359,6 +359,13 @@ const Form = ({
         removeChildNodes(messageRef.current)
         continueBtn.current?.classList.remove("disable")
       }
+    } else if (variant.product?.title === "Single Vision") {
+      rxInfoDispatch({ type: `right-add`, payload: "" })
+      rxInfoDispatch({ type: `left-add`, payload: "" })
+      errorRefs.current[`select-right-add`].classList.add("disable")
+      errorRefs.current[`select-right-add`].querySelector("select").value = ""
+      errorRefs.current[`select-left-add`].classList.add("disable")
+      errorRefs.current[`select-left-add`].querySelector("select").value = ""
     }
     setHasSavedCustomized({
       ...hasSavedCustomized,
@@ -379,6 +386,7 @@ const Form = ({
     // disable axis whether a cyl value is present or not
     if (id.includes("cyl")) {
       let subId = id.split("-")[0]
+      console.log(subId)
       if (evt.target.value !== "0.00") {
         errorRefs.current[`select-${subId}-axis`].classList.remove("disable")
         return
@@ -394,6 +402,7 @@ const Form = ({
       "left-sph",
       "left-cyl",
     ]
+
     if (id.includes("axis")) {
       evt.target.closest(".rx-select")?.classList.remove("select-error")
     }
@@ -654,8 +663,9 @@ const Form = ({
           )}
         </React.Fragment>
       ))}
-      {currentStep === 1 &&
-      selectedVariants.step1.product.title !== "Non-Prescription Lens" ? (
+      {(currentStep === 1 &&
+        selectedVariants.step1.product.title !== "Non-Prescription Lens") ||
+      selectedVariants.step1.product.title === "" ? (
         <div className="rx-info">
           <div className="rx-box">
             <div className="rx-col">
@@ -728,7 +738,16 @@ const Form = ({
                   })}
                 </select>
               </div>
-              <div className="rx-select">
+              <div
+                className={
+                  selectedVariants.step1.product.title === "Single Vision"
+                    ? "rx-select disable"
+                    : "rx-select"
+                }
+                ref={el => {
+                  errorRefs.current["select-right-add"] = el
+                }}
+              >
                 <label htmlFor="right-add">Add</label>
                 <select
                   id="right-add"
@@ -812,7 +831,16 @@ const Form = ({
                   ))}
                 </select>
               </div>
-              <div className="rx-select">
+              <div
+                className={
+                  selectedVariants.step1.product.title === "Single Vision"
+                    ? "rx-select disable"
+                    : "rx-select"
+                }
+                ref={el => {
+                  errorRefs.current["select-left-add"] = el
+                }}
+              >
                 <label htmlFor="left-add">Add</label>
                 <select
                   id="left-add"

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -322,7 +322,15 @@ const Cart = () => {
     return (Number(price) * quantity).toFixed(2)
   }
 
-  const formatItemTitle = (subItem: tnSubItem, stepName: string) => {
+  const formatItemTitle = (
+    subItem: tnSubItem,
+    stepName: string,
+    isCustom: boolean
+  ) => {
+    if (subItem.stepNumber === "0" && isCustom) {
+      console.log(subItem.shopifyItem.variant.title)
+      return subItem.shopifyItem.variant.title.split("-")[0]
+    }
     if (stepName === "CASE") {
       let spl = subItem.shopifyItem.title.split("AO")[0]
       return spl.slice(0, -2)
@@ -455,7 +463,8 @@ const Cart = () => {
                         <span key={subItem.shopifyItem.id}>
                           {formatItemTitle(
                             subItem,
-                            sunglassesStepMap.get(subIndex)
+                            sunglassesStepMap.get(subIndex),
+                            item.isCustom
                           )}
                         </span>
                         <span className="price">
@@ -523,7 +532,11 @@ const Cart = () => {
                       </div>
                       <div className="sub-title" key={subItem.shopifyItem.id}>
                         <span key={subItem.shopifyItem.id}>
-                          {formatItemTitle(subItem, stepMap.get(subIndex))}
+                          {formatItemTitle(
+                            subItem,
+                            stepMap.get(subIndex),
+                            item.isCustom
+                          )}
                         </span>
                         <span className="price">
                           {subItem.shopifyItem.variant.price === "0.00"


### PR DESCRIPTION
- split Frame title in cart page for customized frames
- single vision will now not accept an "Add" field