### PR TITLE
Fixed GTM Error caused by Shopify product not having a default image …

### DIFF
--- a/src/components/product-image-grid.tsx
+++ b/src/components/product-image-grid.tsx
@@ -76,7 +76,7 @@ const ProductImageGrid = (props: { product: any; selectedVariant: any }) => {
           ></GatsbyImage>
         ) : (
           <StaticImage
-            src="../images/product-no-image.jpg"
+            src="../images/no-image-placeholder.jpg"
             alt="No image available"
           ></StaticImage>
         )}

--- a/src/templates/product.tsx
+++ b/src/templates/product.tsx
@@ -186,7 +186,9 @@ const Product = ({ data: { shopifyProduct } }: any) => {
       productType: shopifyProduct.productType,
       image: selectedVariant.image?.originalSrc
         ? selectedVariant.image?.originalSrc
-        : shopifyProduct.featuredImage.originalSrc,
+        : shopifyProduct.featuredImage?.originalSrc
+        ? shopifyProduct.featuredImage.originalSrc
+        : "",
       url: shopifyProduct.onlineStoreUrl,
       vendor: shopifyProduct.vendor,
       price: selectedVariant.price,
@@ -268,7 +270,9 @@ const Product = ({ data: { shopifyProduct } }: any) => {
       productType: shopifyProduct.productType,
       image: selectedVariant?.image?.originalSrc
         ? selectedVariant.image?.originalSrc
-        : shopifyProduct.featuredImage.originalSrc,
+        : shopifyProduct.featuredImage?.originalSrc
+        ? shopifyProduct.featuredImage.originalSrc
+        : "",
       url: shopifyProduct.onlineStoreUrl,
       vendor: shopifyProduct.vendor,
       price: selectedVariant.price,


### PR DESCRIPTION
# Changes
- Fixes the error created by a Shopify product not having a default image set in Shopify.