### PR TITLE
fixed stepthrough price

### DIFF
--- a/src/templates/customize.tsx
+++ b/src/templates/customize.tsx
@@ -126,7 +126,7 @@ const Customize = ({
     contentful: contentfulProduct?.variants && contentfulProduct.variants[0],
     shopify: shopifyProduct.variants[0],
   })
-  const [currentPrice, setCurrentPrice] = useState(
+  const [currentPrice, setCurrentPrice] = useState<string>(
     shopifyProduct.variants[0].price
   )
   const [currentImage, setCurrentImage] = useState({
@@ -175,20 +175,23 @@ const Customize = ({
 
   /* UPDATE PRICING */
   useEffect(() => {
-    let { price } = variant.shopify
-    Object.keys(selectedVariants).forEach(key => {
-      price = Number(price)
-      // step 4 has multiple values
-      if (key === "step4") {
-        selectedVariants[key].forEach(el => {
-          price += Number(el.price)
+    let totalPrice = Number(variant.shopify.price)
+    for (let i = currentStep; i > 0; --i) {
+      const el =
+        i === 5 ? selectedVariants[`case`] : selectedVariants[`step${i}`]
+      if (i === 4) {
+        selectedVariants[`step4`].forEach(subEl => {
+          totalPrice += Number(subEl.price)
         })
       } else {
-        price += Number(selectedVariants[key].price)
+        totalPrice += Number(el.price)
       }
-    })
-    price = Number(price.toFixed(2))
-    setCurrentPrice(price)
+    }
+    setCurrentPrice(totalPrice.toFixed(2))
+  }, [selectedVariants])
+
+  /* UPDATE IMAGE */
+  useEffect(() => {
     changeImage(
       currentStep,
       selectedVariants,

--- a/src/types/customize.d.ts
+++ b/src/types/customize.d.ts
@@ -115,8 +115,8 @@ export interface ShopifyProduct {
   legacyResourceId: string
   onlineStoreUrl: string
   priceRangeV2: {
-    minVariantPrice: number
-    maxVariantPrice: number
+    minVariantPrice: string
+    maxVariantPrice: string
   }
   productType: string
   title: string
@@ -129,7 +129,7 @@ export interface ShopifyProductVariant {
   compareAtPrice: number | null
   id: string
   legacyResourceId: string
-  price: number
+  price: string
   product: {
     collections: {
       handle: string


### PR DESCRIPTION
- previously, if you were to backtrack in stepthrough the price would not change as it would keep any price saved in context
- now, the price will only be calculated until the step it is currently on
- also fixed the issue where the 2 trailing zeros would disappear when adding new prices