### PR TITLE
Added lensType to product carousel key, fixes a bug where refreshing …

### DIFF
--- a/src/templates/product-customizable.tsx
+++ b/src/templates/product-customizable.tsx
@@ -736,7 +736,7 @@ const ProductCustomizable = ({
         <div className="row">
           <div className="col images">
             <ProductCarousel
-              key={selectedVariant?.contentful.id}
+              key={`${selectedVariant?.contentful.id}-${lensType}`}
               imageSet={
                 polarizedImage.length !== 0
                   ? polarizedImage


### PR DESCRIPTION
- Added lensType to product carousel key, fixes a bug where refreshing the default variant will use the sunglasses image instead of the eyeglasses image for the eyeglasses route