### PR TITLE
Enable badges on variant collection

### DIFF
--- a/src/components/product-contentful.tsx
+++ b/src/components/product-contentful.tsx
@@ -116,7 +116,8 @@ const ProductContentful = ({
     collectionHandle.includes("new") ||
     collectionHandle.includes("loser-machine")
   const isExcludedFromDeals =
-    shopifyProduct && shopifyProduct.handle.includes("mooneyes")
+    (shopifyProduct && shopifyProduct.handle.includes("mooneyes")) ||
+    (shopifyProduct && shopifyProduct.handle.includes("loser-machine"))
   const lensType = isSunglasses ? "sunglasses" : "glasses"
 
   // remove variants marked as 'hidden' in shopify
@@ -197,7 +198,7 @@ const ProductContentful = ({
 
   const getBadge = (): { label: string; color: string } | null => {
     try {
-      // bogo is enabled and product is not an exclusion (e.g. Mooneyes products)
+      // bogo is enabled and product is not an exclusion (e.g. collaboration products)
       if (enableBogo && !isExcludedFromDeals) {
         return {
           label: "BOGO",

--- a/src/components/product-contentful.tsx
+++ b/src/components/product-contentful.tsx
@@ -148,7 +148,7 @@ const ProductContentful = ({
   const getSelectedVariantOptionName = (variant: any) => {
     try {
       const optionName = variant.selectedOptions.find(
-        c => c.name === "Color" || c.name === "color"
+        c => c.name.toLowerCase() === "color"
       )
       const optionValue = optionName ? optionName.value : ""
       const colorName = optionValue.split("-")[0].trim()

--- a/src/components/variant.tsx
+++ b/src/components/variant.tsx
@@ -5,6 +5,7 @@ import { GatsbyImage } from "gatsby-plugin-image"
 import ProductAction from "./collection-product-action"
 import type { ContentfulProductVariant } from "../types/contentful"
 import { isDiscounted } from "../helpers/shopify"
+import Badge from "./badge"
 
 const Component = styled.div`
   margin-bottom: 1.45rem;
@@ -96,6 +97,7 @@ type Props = {
   compareAtPrice: string
   productHandle: string
   name: string
+  badge: { label: string; color: string } | null
 }
 
 const Variant = ({
@@ -104,6 +106,7 @@ const Variant = ({
   productHandle,
   name,
   compareAtPrice,
+  badge,
 }: Props) => {
   const { sku } = contentfulData
   const link = `/products/${productHandle}?variant=${sku}`
@@ -116,6 +119,7 @@ const Variant = ({
             image={contentfulData.featuredImage.data}
             alt={"contentfulData.title"}
           />
+          {badge && <Badge label={badge.label} color={badge.color} />}
         </Link>
         <ProductAction>
           <Link to={link}>View Product</Link>

--- a/src/templates/product-customizable.tsx
+++ b/src/templates/product-customizable.tsx
@@ -530,7 +530,9 @@ const ProductCustomizable = ({ data, location: any }: Props) => {
 
   const getSelectedVariantOptionName = (variant: any) => {
     try {
-      const optionName = variant.selectedOptions.find(c => c.name === "Color")
+      const optionName = variant.selectedOptions.find(
+        c => c.name.toLowerCase() === "color"
+      )
       const optionValue = optionName ? optionName.value : ""
       const colorName = optionValue.split("-")[0].trim()
       return colorName


### PR DESCRIPTION
PR does two things:
1. fix that cleans up bug related to grabbing `color option` name 
2. enables badging on variant collection pages