### PR TITLE
Fix collection page price swap

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,17 @@
 const path = require("path")
 
+// patch development store schema
+if (process.env.NODE_ENV === "development") {
+  exports.createSchemaCustomization = ({ actions }) => {
+    const { createTypes } = actions
+    createTypes(`
+      type ShopifyProduct {
+        onlineStoreUrl: String
+      }
+    `)
+  }
+}
+
 exports.createPages = async ({ graphql, actions: { createPage } }) => {
   const pageable = await graphql(`
     query PagesQuery {

--- a/src/components/customization/form.tsx
+++ b/src/components/customization/form.tsx
@@ -377,6 +377,7 @@ const Form = ({
   const prices = shopifyCollection.products.map(p => ({
     id: p.variants[0].legacyResourceId,
     price: p.variants[0].price,
+    handle: p.handle,
   }))
 
   const { offer, isApplicable, discountedPrices } =

--- a/src/components/product.tsx
+++ b/src/components/product.tsx
@@ -10,6 +10,7 @@ import { useQuantityQuery } from "../hooks/useQuantityQuery"
 import { addedToCartGTMEvent } from "../helpers/gtm"
 import { isDiscounted } from "../helpers/shopify"
 import Badge from "./badge"
+import useDiscountIdentifier from "../hooks/useDiscountIdentifier"
 
 const Component = styled.article`
   h3,
@@ -86,17 +87,6 @@ const Component = styled.article`
   }
 `
 
-const createDiscountApiPayload = (shopifyProduct): any[] => {
-  try {
-    return shopifyProduct.variants.map(v => ({
-      price: v.price,
-      id: v.legacyResourceId,
-    }))
-  } catch (error) {
-    return []
-  }
-}
-
 const Product = ({
   data,
   collection,
@@ -116,6 +106,8 @@ const Product = ({
 }) => {
   const selectedVariant = data.variants[0]
   const { isApplicable, offer, discountedPrice } = discount
+
+  const { overwriteLabel } = useDiscountIdentifier()
 
   const quantityLevels = useQuantityQuery(data.handle, data.variants.length)
 
@@ -205,7 +197,7 @@ const Product = ({
               {isApplicable && (
                 <div className="badge-container">
                   <Badge
-                    label={offer}
+                    label={overwriteLabel ? "Sale" : offer}
                     color={"red"}
                     position="absolute"
                     top={0}

--- a/src/hooks/useDiscountIdentifier.tsx
+++ b/src/hooks/useDiscountIdentifier.tsx
@@ -13,6 +13,7 @@ export const useDiscountIdentifier = () => {
     discountIdentifier: data.contentfulHomepage.discountIdentifier as string,
     enableDiscountIdentifier: data.contentfulHomepage
       .enableDiscountIdentifier as boolean,
+    overwriteLabel: true,
   }
 }
 

--- a/src/hooks/useRandomizeCollection.tsx
+++ b/src/hooks/useRandomizeCollection.tsx
@@ -92,6 +92,14 @@ export const useRandomizeCollection = (currentProductId: string) => {
         onlineStoreUrl: string | null
         storefrontId: string
       }) => {
+        if (process.env.NODE_ENV === "development") {
+          return (
+            el.storefrontId !== currentProductId &&
+            !el.tags.includes("upsell_item") &&
+            !el.hasOutOfStockVariants &&
+            el.productType !== "Gift Card"
+          )
+        }
         return (
           el.storefrontId !== currentProductId &&
           !el.tags.includes("upsell_item") &&

--- a/src/templates/collection.tsx
+++ b/src/templates/collection.tsx
@@ -153,6 +153,7 @@ const Collection = ({
         return {
           id: v.legacyResourceId,
           price: v.price,
+          handle: p.handle,
         }
       })
     })


### PR DESCRIPTION
I have updated the collection page price swap. The collection page price swap only worked with discounts targeting collections. This updates it to handle discounts targeting products and product variants.

This update also includes necessary changes for the staging site.