### PR TITLE
Fix Customization Step 2

### DIFF
--- a/src/components/customization/step2.tsx
+++ b/src/components/customization/step2.tsx
@@ -23,11 +23,17 @@ const Step2: React.FC<Props> = ({ handle }) => {
 
   const prices = useMemo(
     () =>
-      shopifyCollection.products.map(p => ({
-        id: p.variants[0].legacyResourceId,
-        price: p.variants[0].price,
-        handle: p.handle,
-      })),
+      shopifyCollection.products
+        .map(p =>
+          p.variants.map(v => {
+            return {
+              id: v.legacyResourceId,
+              price: v.price,
+              handle: p.handle,
+            }
+          })
+        )
+        .flat(),
     [shopifyCollection]
   )
 


### PR DESCRIPTION
This fixes a bug on customization step 2. The collection discount price swap was using the first variant to calculate the discount and was not calculating any other variant discounts.