### PR TITLE
Gatsby Source Shopify Plugin Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "gatsby-plugin-styled-components": "^6.14.0",
         "gatsby-source-contentful": "^8.14.0",
         "gatsby-source-filesystem": "^5.14.0",
-        "gatsby-source-shopify": "^8.14.0",
+        "gatsby-source-shopify": "^9.0.0",
         "gatsby-source-yotpo": "^3.0.5",
         "gatsby-transformer-sharp": "^5.14.0",
         "graphql": "^16.9.0",
@@ -15281,9 +15281,9 @@
       }
     },
     "node_modules/gatsby-source-shopify": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-shopify/-/gatsby-source-shopify-8.14.0.tgz",
-      "integrity": "sha512-NImfEC66Kp3hgYa34nlVqPE0VXLfzuBXtDbD8q1fYrpA7PAMNaWddsqfh0b1zWgBy3/RikHAghMuGVWafW3Oxw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-shopify/-/gatsby-source-shopify-9.0.0.tgz",
+      "integrity": "sha512-LRCW0Jm1+sNIt/xa8l0JWaarqW03RwOVeP2sBKQeJXP9lkKIfeuL7WBnbw/eDO7QbtRdLcAMfYhnfTU6UE7ZpA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "gatsby-core-utils": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gatsby-plugin-styled-components": "^6.14.0",
     "gatsby-source-contentful": "^8.14.0",
     "gatsby-source-filesystem": "^5.14.0",
-    "gatsby-source-shopify": "^8.14.0",
+    "gatsby-source-shopify": "^9.0.0",
     "gatsby-source-yotpo": "^3.0.5",
     "gatsby-transformer-sharp": "^5.14.0",
     "graphql": "^16.9.0",


### PR DESCRIPTION
Updated the Gatsby Source Shopify Plugin to version 9.0 to use Shopify API Version 2024-04.