### PR TITLE
Fix lens customization typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v.0.12 - 2025-08-05
+## v.0.12.1 - 2025-08-05
 
 **Breaking Changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v.0.12 - 2025-08-05
+
+**Breaking Changes**
+
+- Fixed the spelling of the Lens Customization product type. The previous misspelling "Lense Customization" has been corrected to "Lens Customization". This will require updates in any related code or configurations that referenced the old spelling.
+
 ## v.0.12 - 2025-05-05
 
 **Features**

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -98,7 +98,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
       }
 
       if (
-        productType !== "Lense Customization" &&
+        productType !== "Lense Customization" && // TODO: Remove this once the product type is fixed in Shopify
         productType !== "Lens Customization" &&
         productType !== "Lenses" &&
         productType !== "Upsell AO" &&

--- a/src/utils/algolia-queries.js
+++ b/src/utils/algolia-queries.js
@@ -10,7 +10,8 @@ const indexName =
 
 const excludedProductTypes = [
   "Insurance",
-  "Lense Customization",
+  "Lense Customization", // TODO: Remove this once the product type is fixed in Shopify
+  "Lens Customization",
   "Lenses",
   "Upsell AO",
   "Case Add-Ons",


### PR DESCRIPTION
Fixed the spelling of the Lens Customization product type. The previous misspelling "Lense Customization" has been corrected to "Lens Customization". This will require updates in any related code or configurations that referenced the old spelling.